### PR TITLE
feat(quality): Code formatting SDKCF-137

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,34 @@
+# mostly based on https://github.com/NYTimes/objective-c-style-guide
+---
+# common
+SortIncludes: false
+UseTab: Never
+---
+Language:        ObjC
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterEnum: true
+    AfterControlStatement: false
+    AfterFunction: false
+    AfterObjCDeclaration: true
+    BeforeCatch: true
+    BeforeElse: true
+ColumnLimit: 0
+IndentWidth: 4
+MaxEmptyLinesToKeep: 1
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PointerBindsToType: false
+SpacesBeforeTrailingComments: 1
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpacesInContainerLiterals: false
+---
+Language: Cpp
+DisableFormat: true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,5 +126,15 @@ platform :ios do
       module_version: options[:module_version]
     )
   end
+
+  desc "Set up project, including git hooks"
+  lane :setup_project do
+    setup_git_hooks
+  end
+
+  desc "Format Objective-C code using clang-format tool"
+  lane :format_objc do |options|
+    apply_codestyle(options[:ignore_exit_code])
+  end
 end
 # vim:syntax=ruby:et:sts=2:sw=2:ts=2:ff=unix:

--- a/fastlane/actions/apply_codestyle.rb
+++ b/fastlane/actions/apply_codestyle.rb
@@ -1,0 +1,54 @@
+require 'fileutils'
+
+module Fastlane
+  module Actions
+    class ApplyCodestyleAction < Action
+      def self.run(params)
+        UI.message("Format Objective-C code files in-place with clang-format tool")
+
+        begin
+          # download latest clang-format config
+          sh("curl -s -o .clang-format https://raw.githubusercontent.com/rakutentech/ios-buildconfig/master/.clang-format")
+
+          # format Objective-C files in-place
+          sh("find . -iname *.h -o -iname *.m | xargs clang-format -style=file -fallback-style=none -i")
+        rescue
+          handle_format_error(params[:ignore_exit_status], $?.exitstatus)
+        end
+      end
+
+      def self.description
+        "Format Objective-C code files in-place with clang-format tool"
+      end
+
+      def self.output
+      end
+
+      def self.authors
+        ["rem"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+
+      def self.handle_format_error(ignore_exit_status, exit_status)
+        if ignore_exit_status
+          failure_suffix = 'which would normally fail the build.'
+          secondary_message = 'fastlane will continue because the `ignore_exit_status` option was used! 🙈'
+        else
+          failure_suffix = 'which represents a failure.'
+          secondary_message = 'If you want fastlane to continue anyway, use the `ignore_exit_status` option. 🙈'
+        end
+
+        UI.important("")
+        UI.important("Formatting finished with exit code #{exit_status}, #{failure_suffix}")
+        UI.important(secondary_message)
+        UI.important("")
+        UI.user_error!("Formatting finished with errors (exit code: #{exit_status})") unless ignore_exit_status
+      end
+    end
+  end
+end
+
+# vim:syntax=ruby:et:sts=2:sw=2:ts=2:ff=unix:

--- a/fastlane/actions/setup_git_hooks.rb
+++ b/fastlane/actions/setup_git_hooks.rb
@@ -1,0 +1,38 @@
+require 'fileutils'
+
+module Fastlane
+  module Actions
+    class SetupGitHooksAction < Action
+      def self.run(params)
+        UI.message("Set up git hooks: clang-format pre-commit hook")
+
+        # download clang-format config
+        sh("curl -s -o .clang-format https://raw.githubusercontent.com/rakutentech/ios-buildconfig/master/.clang-format")
+
+        # download pre-commit hook and copy to .git/hooks/pre-commit
+        sh("curl -s -o pre-commit https://raw.githubusercontent.com/rakutentech/ios-buildconfig/master/scripts/check-files-clang")
+        sh("chmod +x pre-commit")
+        FileUtils.rm '.git/hooks/pre-commit', :force => true
+        FileUtils.mkdir_p('.git/hooks')
+        FileUtils.mv 'pre-commit', '.git/hooks/', :force => true
+      end
+
+      def self.description
+        "Set up git hooks: clang-format pre-commit hook"
+      end
+
+      def self.output
+      end
+
+      def self.authors
+        ["rem"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end
+
+# vim:syntax=ruby:et:sts=2:sw=2:ts=2:ff=unix:

--- a/scripts/check-files-clang
+++ b/scripts/check-files-clang
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+export PATH=/usr/local/bin:$PATH
+
+# run clang-format on all .m and .h files
+find . -iname *.h -o -iname *.m | xargs clang-format -style=file -output-replacements-xml |
+  grep "<replacement " >/dev/null
+
+# if "<replacement " is found it means that clang-format wants to make changes
+if [ $? -ne 1 ]; then
+    echo "\n\nFiles do not match clang-format.\nRun 'fastlane ios format_objc' to re-format or commit with --no-verify."
+    exit 1
+fi


### PR DESCRIPTION
- add clang-format config file that closely matches NYT Objective-C code style guide
- add fastlane lane to set up a git hook that checks code formatting via clang-format
- add fastlane lane to format code via clang-format