### PR TITLE
build: fix ruby folder permission problem on Catalina

### DIFF
--- a/vars/sharedPipeline.groovy
+++ b/vars/sharedPipeline.groovy
@@ -12,7 +12,7 @@ def call(body = {}) {
 
         stage('Build then test') {
           runSteps(pipelineParams.preBuildSteps)
-          sh 'bundle install'
+          sh 'bundle install --path vendor/bundle'
           sh 'bundle exec fastlane ci'
         }
 


### PR DESCRIPTION
due to ruby folder permission problems on Catalina install the gems to a vendor path