### PR TITLE
improve: Use dynamic slack channel name/id in Jenkins pipeline

### DIFF
--- a/vars/notifySlackFixed.groovy
+++ b/vars/notifySlackFixed.groovy
@@ -1,5 +1,5 @@
 def call() {
-  slackSend channel: '#sdk-dev-ci',
-      color: 'good',
-      message: "${currentBuild.fullDisplayName} is back to normal (<${env.BUILD_URL}|Open>)"
+  	slackSend channel: "${env.SLACK_CHANNEL_SDK}",
+        color: 'good',
+        message: "${currentBuild.fullDisplayName} is back to normal (<${env.BUILD_URL}|Open>)"
 }

--- a/vars/notifySlackRegression.groovy
+++ b/vars/notifySlackRegression.groovy
@@ -1,5 +1,5 @@
 def call() {
-  slackSend channel: '#sdk-dev-ci',
+  	slackSend channel: "${env.SLACK_CHANNEL_SDK}",
         color: 'danger',
         message: "${currentBuild.fullDisplayName} failed! (<${env.BUILD_URL}|Open>)"
 }


### PR DESCRIPTION
`SLACK_CHANNEL_SDK` var can be defined in Jenkins global or job settings.
The var can contain either channel's name or id