### PR TITLE
improve: keep swiftlint output in the logs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -133,7 +133,6 @@ platform :ios do
       ocpath = './artifacts/lint-results.html'
     end
 
-    swiftpath = './artifacts/swiftlint.result.json'
     module_name = ENV['REM_MODULE_NAME'] || ENV['REM_FL_TESTS_SLATHER_BASENAME']
 
     begin
@@ -155,11 +154,10 @@ platform :ios do
         swiftlint(
           mode: :lint,
           strict: true,
-          output_file: swiftpath,
           config_file: '.swiftlint.yml',
           ignore_exit_status: false)
       rescue
-        UI.error '`swiftlint` found a problem. Please check ' + swiftpath
+        UI.error '`swiftlint` found a problem. Please check the logs above'
         raise
       end
     else


### PR DESCRIPTION
In case of `swiftlint` error on CI machine it's easier to debug by analysing logs than searching for the artifact with output.