### PR TITLE
fix: use automatic repo discovery for Jenkins GitHub status setter step

### DIFF
--- a/vars/setGitHubBuildStatus.groovy
+++ b/vars/setGitHubBuildStatus.groovy
@@ -1,7 +1,7 @@
 def call(String message, String state) {
   step([
     $class: "GitHubCommitStatusSetter",
-    reposSource: [$class: "ManuallyEnteredRepositorySource", url: env.GIT_URL],
+    reposSource: [$class: "AnyDefinedRepositorySource"],
     contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
     commitShaSource: [$class: "ManuallyEnteredShaSource", sha: (env.GIT_COMMIT ?: env.sha)],
     errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],


### PR DESCRIPTION
The url provided in `ManuallyEnteredRepositorySource` isn't just a simple url.
The fix requires "GitHub Servers" to be set in Jenkins global settings.