### PR TITLE
improve: export xcresult test bundle

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,6 +17,7 @@ platform :ios do
     scan(
       clean: true,
       skip_build: true,
+      result_bundle: true,
       output_directory: './artifacts/unit-tests',
       scheme: ENV['REM_FL_TESTS_SCHEME'] || 'Tests',
       device: ENV['REM_FL_TESTS_DEVICE'] || 'iPhone 11',


### PR DESCRIPTION
Export a native `.xcresult` test bundle to `output_directory` to be consumed by [Bitrise Test Reports](https://devcenter.bitrise.io/testing/test-reports/) (or [GitHub Actions](https://github.com/marketplace/actions/xcresulttool)).

`$ fastlane ci` will now create:

`artifacts/unit-tests/<ENV['REM_FL_TESTS_SCHEME'] || 'Tests'>.xcresult`