### PR TITLE
ci: deploy_ghpages lane support multi-module docs (SDKCF-4445)

### DIFF
--- a/fastlane/actions/gh_pages.rb
+++ b/fastlane/actions/gh_pages.rb
@@ -27,7 +27,7 @@ module Fastlane
         # Download theme and generate docs
         UI.user_error!("svn not installed") unless system("command -v svn")
         sh "svn export https://github.com/rakutentech/ios-buildconfig/trunk/jazzy_themes jazzy_themes --force"
-        other_action.documentation(module_name: module_name, module_version: module_version)
+        sh "bundle exec jazzy --output artifacts/docs/#{module_version} --theme jazzy_themes/apple_versions"
 
         # Generate html files
         versions_string = File.readlines("_versions").map{|line| "\"#{line.strip}\""}.join(",")

--- a/fastlane/actions/gh_pages.rb
+++ b/fastlane/actions/gh_pages.rb
@@ -14,9 +14,6 @@ module Fastlane
         UI.user_error!("Missing `_versions` file") unless File.exists?("_versions")
         UI.user_error!("Missing `.jazzy.yaml` file") unless File.exists?(".jazzy.yaml")
         module_version = YAML.load(File.read(".jazzy.yaml"))["module_version"]
-        array = module_version.split(/[.]/)
-        short_version = array[0] + "." + array[1]
-        module_version = short_version
         UI.user_error!("Missing `module_version` parameter in .jazzy.yaml file") unless module_version != nil
         module_name = YAML.load(File.read(".jazzy.yaml"))["module"]
         UI.user_error!("Missing `module` parameter in .jazzy.yaml file") unless module_name != nil
@@ -36,7 +33,7 @@ module Fastlane
         versions_string = File.readlines("_versions").map{|line| "\"#{line.strip}\""}.join(",")
         versions_js = "const Versions = [" + versions_string + "];"
         File.open("#{docs_folder}/versions.js", "w") { |f| f.write versions_js }
-        File.open("#{docs_folder}/index.html", "w") { |f| f.write "<html><head><meta http-equiv=\"refresh\" content=\"0; URL=#{module_name}-#{module_version}/index.html\" /></head></html>" }
+        File.open("#{docs_folder}/index.html", "w") { |f| f.write "<html><head><meta http-equiv=\"refresh\" content=\"0; URL=#{module_version}/index.html\" /></head></html>" }
 
         UI.message("Deploying documentation")
         # Deploy to GitHub Pages

--- a/fastlane/actions/gh_pages.rb
+++ b/fastlane/actions/gh_pages.rb
@@ -14,26 +14,33 @@ module Fastlane
         UI.user_error!("Missing `_versions` file") unless File.exists?("_versions")
         UI.user_error!("Missing `.jazzy.yaml` file") unless File.exists?(".jazzy.yaml")
         module_version = YAML.load(File.read(".jazzy.yaml"))["module_version"]
+        array = module_version.split(/[.]/)
+        short_version = array[0] + "." + array[1]
+        module_version = short_version
         UI.user_error!("Missing `module_version` parameter in .jazzy.yaml file") unless module_version != nil
+        module_name = YAML.load(File.read(".jazzy.yaml"))["module"]
+        UI.user_error!("Missing `module` parameter in .jazzy.yaml file") unless module_name != nil
+        docs_folder = "artifacts/docs"
 
         # Prepare environment
-        FileUtils.rm_rf("artifacts/docs")
-        sh "git clone --single-branch --branch gh-pages #{ghpages_url} artifacts/docs"
-        FileUtils.rm_rf("artifacts/docs/#{module_version}")
+        FileUtils.rm_rf(docs_folder)
+        sh "git clone --single-branch --branch gh-pages #{ghpages_url} #{docs_folder}"
+        FileUtils.rm_rf("#{docs_folder}/#{module_version}")
 
         # Download theme and generate docs
+        UI.user_error!("svn not installed") unless system("command -v svn")
         sh "svn export https://github.com/rakutentech/ios-buildconfig/trunk/jazzy_themes jazzy_themes --force"
-        sh "bundle exec jazzy --output artifacts/docs/#{module_version} --theme jazzy_themes/apple_versions"
+        other_action.documentation(module_name: module_name, module_version: module_version)
 
         # Generate html files
         versions_string = File.readlines("_versions").map{|line| "\"#{line.strip}\""}.join(",")
         versions_js = "const Versions = [" + versions_string + "];"
-        File.open("artifacts/docs/versions.js", "w") { |f| f.write versions_js }
-        File.open("artifacts/docs/index.html", "w") { |f| f.write "<html><head><meta http-equiv=\"refresh\" content=\"0; URL=#{module_version}/index.html\" /></head></html>" }
+        File.open("#{docs_folder}/versions.js", "w") { |f| f.write versions_js }
+        File.open("#{docs_folder}/index.html", "w") { |f| f.write "<html><head><meta http-equiv=\"refresh\" content=\"0; URL=#{module_name}-#{module_version}/index.html\" /></head></html>" }
 
         UI.message("Deploying documentation")
         # Deploy to GitHub Pages
-        git_cmd_config = "--git-dir=artifacts/docs/.git --work-tree=artifacts/docs/"
+        git_cmd_config = "--git-dir=#{docs_folder}/.git --work-tree=#{docs_folder}/"
         sh "git #{git_cmd_config} add . -f"
         sh "git #{git_cmd_config} commit -m \"Deploy Jazzy docs for version #{module_version}\""
 


### PR DESCRIPTION
Should be used in a repo that uses this repo  from `import_from_git`. Your repo should have:

_versions
```
1.0.0
```

.jazzy.yaml
```
module: MyModule
module_version: 1.0.0
```

You'll need to have a GitHub repo with GitHub Pages enabled. We assume you have your GH Pages under `/gh-pages`.

Invoke by:

```bash
bundle exec fastlane ios deploy_ghpages ghpages_url:https://github.com/apparition47/my-repo.git github_token:my-pat-token-with-repo-role
```