### PR TITLE
feat: add xccov -> sonarqube coverage conversion script

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,11 +30,12 @@ platform :ios do
     slather(
       output_directory: './artifacts/coverage',
       scheme: ENV['REM_FL_TESTS_SCHEME'] || 'Tests',
-      cobertura_xml: true,
+      sonarqube_xml: true,
+      use_bundle_exec: true,
       proj: ENV['REM_FL_TESTS_PROJECT'],
       workspace: ENV['REM_FL_TESTS_WORKSPACE'],
       binary_basename: ENV['REM_FL_TESTS_SLATHER_BASENAME'],
-      ignore: '../*')
+      ignore: '*.{h,m}')
 
     lint_module
     format_objc(check_only: true)

--- a/scripts/sdk-api-diff/sdk-api-diff.sh
+++ b/scripts/sdk-api-diff/sdk-api-diff.sh
@@ -99,6 +99,7 @@ if [ "$SPM_MODE" = false ] ; then
   set +e # diff exit code 1 means that differences were found.
   diff moduleA.swift moduleB.swift > $MODULE_NAME.diff
   set -e
+  echo "API diff generated to $(pwd)/$MODULE_NAME.diff"
 
   # Print API diff summary
   xcrun --toolchain swift swift-api-digester --dump-sdk -module $MODULE_NAME -I $MODULE_A_DIR -F $MODULE_A_DIR -sdk $SDK_DIR -o moduleA.json -target $TARGET_NAME

--- a/scripts/xccov-to-sonarqube-generic-swift.sh
+++ b/scripts/xccov-to-sonarqube-generic-swift.sh
@@ -1,0 +1,45 @@
+# This file is based on xccov-to-sonarqube-generic.sh script from https://github.com/SonarSource/sonar-scanning-examples/tree/master/swift-coverage
+# commit: ae7f0f760d7a5585c564597d184213b0a09eef41
+# It uses pre Xcode 11 version of the script to avoid Info.plist error in xcov generated .xccovarchive files
+# The script was modified to exclude .h and .m files from the report
+
+#!/usr/bin/env bash
+set -euo pipefail
+
+function convert_file {
+  local xccovarchive_file="$1"
+  local file_name="$2"
+  local xccov_options="$3"
+  echo "  <file path=\"$file_name\">"
+  xcrun xccov view $xccov_options --file "$file_name" "$xccovarchive_file" | \
+    sed -n '
+    s/^ *\([0-9][0-9]*\): 0.*$/    <lineToCover lineNumber="\1" covered="false"\/>/p;
+    s/^ *\([0-9][0-9]*\): [1-9].*$/    <lineToCover lineNumber="\1" covered="true"\/>/p
+    '
+  echo '  </file>'
+}
+
+function xccov_to_generic {
+  echo '<coverage version="1">'
+  for xccovarchive_file in "$@"; do
+    if [[ ! -d $xccovarchive_file ]]
+    then
+      echo "Coverage FILE NOT FOUND AT PATH: $xccovarchive_file" 1>&2;
+      exit 1
+    fi
+    local xccov_options=""
+    if [[ $xccovarchive_file == *".xcresult"* ]]; then
+      xccov_options="--archive"
+    fi
+    xcrun xccov view $xccov_options --file-list "$xccovarchive_file" | while read -r file_name; do
+      if [[ $file_name = *.m ]] || [[ $file_name = *.h ]]
+      then
+        continue
+      fi
+      convert_file "$xccovarchive_file" "$file_name" "$xccov_options"
+    done
+  done
+  echo '</coverage>'
+}
+
+xccov_to_generic "$@"


### PR DESCRIPTION
Added modified script based on https://github.com/SonarSource/sonar-scanning-examples/tree/master/swift-coverage
Slather now produces `sonarqube-generic-coverage.xml ` instead of `cobertura.xml`.
The new xml can be used with SonarQube as `sonar.externalIssuesReportPaths`