### PR TITLE
improve: pod lib lint on shared_tests if podspecs exist (SDKCF-4769)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -110,16 +110,18 @@ platform :ios do
   end
 
   private_lane :lint_podspec do |options|
-    pod_lib_lint(sources: [options[:source], "https://github.com/CocoaPods/Specs"], allow_warnings: true, verbose: false)
+    pod_lib_lint(sources: ["https://github.com/CocoaPods/Specs", options[:source]], allow_warnings: true, verbose: false)
   end
 
   desc 'Lint the podspec on STG spec repo'
   lane :stg_lint do
+    UI.message("REM_FL_STG_SPEC_REPO podspec source param isn't set") unless ENV["REM_FL_STG_SPEC_REPO"]
     lint_podspec(source: ENV['REM_FL_STG_SPEC_REPO'])
   end
 
   desc 'Lint the podspec on PROD spec repo'
   lane :prd_lint do
+    UI.message("REM_FL_SPEC_REPO podspec source param isn't set") unless ENV["REM_FL_SPEC_REPO"]
     lint_podspec(source: ENV['REM_FL_SPEC_REPO'])
   end
 
@@ -152,7 +154,7 @@ platform :ios do
 
     if Dir.glob("../*.podspec").length > 0
       begin
-        pod_lib_lint(allow_warnings: true)
+        prd_lint
       rescue
         UI.error '`pod lib lint` found a problem. Please check the logs above'
         raise

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -150,6 +150,17 @@ platform :ios do
       UI.error '`oclint` found a problem. Please check ' + ocpath
     end
 
+    if Dir.glob("../*.podspec").length > 0
+      begin
+        pod_lib_lint(allow_warnings: true)
+      rescue
+        UI.error '`pod lib lint` found a problem. Please check the logs above'
+        raise
+      end
+    else
+      UI.important 'No `.podspec` files found. Skipping Pod Lib Lint step'
+    end
+
     if File.exist?('../.swiftlint.yml')
       begin
         swiftlint(


### PR DESCRIPTION
Runs `pod lib lint` against `*.podspec` files in the root dir if they exist. Adds ~65s to the testing pipeline to one of our repos.