### PR TITLE
improve: run `pod repo update` before `pod lib lint`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,7 +109,13 @@ platform :ios do
     )
   end
 
-  private_lane :lint_podspec do |options|
+  lane :lint_podspec do |options|
+    begin
+      sh "bundle exec pod repo update"
+    rescue
+      # no Gemfile
+      sh "pod repo update"
+    end
     pod_lib_lint(sources: ["https://cdn.cocoapods.org", options[:source]], allow_warnings: true, verbose: false)
   end
 


### PR DESCRIPTION
`pod lib lint` can fail if repos are not up to date.

Maybe having just one command with `bundle exec` is enough?
Technically `pod repo update` can be run as a part of other lane used in standard build process - it's controlled by `REM_FL_CP_REPO_UPDATE` env var