### PR TITLE
feat: deploy_ghpages support SSH git URLs with Deploy Keys

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -199,6 +199,7 @@ platform :ios do
     check_artifacts_dir
     gh_pages(
       ghpages_url: options[:ghpages_url],
+      deploy_key: options[:deploy_key],
       github_token: options[:github_token]
     )
   end

--- a/fastlane/actions/gh_pages.rb
+++ b/fastlane/actions/gh_pages.rb
@@ -6,6 +6,7 @@ module Fastlane
   module Actions
     class GhPagesAction < Action
       def self.run(params)
+        deploykey = params[:deploykey]
         github_token = params[:github_token]
         ghpages_url = params[:ghpages_url]
 
@@ -19,6 +20,17 @@ module Fastlane
         UI.user_error!("Missing `module` parameter in .jazzy.yaml file") unless module_name != nil
         docs_folder = "artifacts/docs"
 
+        if deploykey == nil && github_token == nil
+          UI.user_error!(":deploykey or :github_token must be specified")
+        end
+        if !ghpages_url.include?("git@") && deploykey != nil
+          UI.user_error!(":ghpages_url must be a SSH URL when using :deploykey")
+        end
+        git_ssh_command = ""
+        if deploykey != nil
+          git_ssh_command = "ssh -i #{deploykey} -o IdentitiesOnly=yes"
+        end
+
         # Prepare environment
         FileUtils.rm_rf(docs_folder)
         sh "git clone --single-branch --branch gh-pages #{ghpages_url} #{docs_folder}"
@@ -27,7 +39,7 @@ module Fastlane
         # Download theme and generate docs
         UI.user_error!("svn not installed") unless system("command -v svn")
         sh "svn export https://github.com/rakutentech/ios-buildconfig/trunk/jazzy_themes jazzy_themes --force"
-        sh "bundle exec jazzy --output artifacts/docs/#{module_version} --theme jazzy_themes/apple_versions"
+        sh "bundle exec jazzy --output artifacts/docs/#{module_version} --theme jazzy_themes/apple_versions --exclude=RakutenWebClientKit"
 
         # Generate html files
         versions_string = File.readlines("_versions").map{|line| "\"#{line.strip}\""}.join(",")
@@ -41,9 +53,13 @@ module Fastlane
         sh "git #{git_cmd_config} add . -f"
         sh "git #{git_cmd_config} commit -m \"Deploy Jazzy docs for version #{module_version}\""
 
-        gh_host = URI.parse(ghpages_url).host
-        sh "git #{git_cmd_config} config url.\"https://x-token-auth:#{github_token}@#{gh_host}\".InsteadOf https://#{gh_host}"
-        sh "git #{git_cmd_config} push origin gh-pages"
+        if deploykey != nil then
+          sh "GIT_SSH_COMMAND='ssh -i #{deploykey} -o IdentitiesOnly=yes' git #{git_cmd_config} push origin gh-pages"
+        else
+          gh_host = URI.parse(ghpages_url).host
+          sh "git #{git_cmd_config} config url.\"https://x-token-auth:#{github_token}@#{gh_host}\".InsteadOf https://#{gh_host}"
+          sh "git #{git_cmd_config} push origin gh-pages"
+        end
 
         # Cleanup
         FileUtils.rm_rf("jazzy_themes")
@@ -54,11 +70,24 @@ module Fastlane
       end
 
       def self.available_options
+        conflict_block = Proc.new do |other|
+          UI.user_error! "Unexpected conflict with option #{other}" unless [:github_token, :deploykey].include?(other)
+          UI.message "Ignoring :github_token in favor of :deploykey"
+        end
         [
           FastlaneCore::ConfigItem.new(key: :ghpages_url,
-                                       description: "Repository URL to store generated documentation (gh-pages branch)"),
+                                       description: "Repository SSH URL to store generated documentation (gh-pages branch)"),
+          FastlaneCore::ConfigItem.new(key: :deploykey,
+                                       description: "Path to private SSH GitHub Deploy Key",
+                                       env_name: "DEPLOYKEY",
+                                       optional: true,
+                                       conflicting_options: [:github_token],
+                                       conflict_block: conflict_block),
           FastlaneCore::ConfigItem.new(key: :github_token,
-                                       description: "GitHub API token for publising generated documentation")
+                                       description: "GitHub API token for publising generated documentation",
+                                       optional: true,
+                                       conflicting_options: [:deploykey],
+                                       conflict_block: conflict_block)
         ]
       end
 


### PR DESCRIPTION
Allow repo-specific Deploy Keys instead of user global PATs and support SSH-based repo URLs.

SSH+Deploy Key Usage:
```bash
$ fastlane ios deploy_ghpages \
ghpages_url:git@github.com:rakutentech/my-gh-docs-repo.git \
deploy_key:/Users/user/PrivateSSHKeys/id_rsa
```

(current) HTTPS+PAT Usage:
```bash
$ fastlane ios deploy_ghpages \
ghpages_url:https://github.com/rakutentech/my-gh-docs-repo.git \
github_token:my-pat
```