### PR TITLE
improve: silently handle Dependency Check errors

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,8 +38,12 @@ platform :ios do
       ignore: '*.{h,m}')
 
     lint_module
-    check_dependencies
     format_objc(check_only: true)
+    begin
+      check_dependencies
+    rescue
+      UI.error 'Dependency check errored. Please check logs'
+    end
   end
 
   desc "Build a sample"


### PR DESCRIPTION
This improvement will prevent builds from failing in case of errors during `check_dependencies` step.

The test build on Bitrise succeeded.