### PR TITLE
improve: add deploy artifacts step in Bitrise workflows

### DIFF
--- a/shared-bitrise.yml
+++ b/shared-bitrise.yml
@@ -10,24 +10,20 @@ workflows:
     after_run:
     - _sonarqube
     - _report
+    - _deploy_artifacts
     steps:
     - fastlane@3:
         inputs:
         - update_fastlane: 'false'
         - lane: ci
         title: Build & Test
-    - deploy-to-bitrise-io@2:
-        is_skippable: true
-        inputs:
-        - is_enable_public_page: "false"
-        - deploy_path: ./artifacts
-        - is_compress: "true"
 
   deploy:
     before_run:
     - _setup
     after_run:
     - _deploy_docs_worker    
+    - _deploy_artifacts
     steps:
     - script@1:
         title: Lint and push Cocoapods trunk
@@ -38,12 +34,6 @@ workflows:
 
             bundle exec pod spec lint --allow-warnings
             bundle exec pod trunk push --allow-warnings --verbose
-    - deploy-to-bitrise-io@2:
-        is_skippable: true
-        inputs:
-        - is_enable_public_page: "false"
-        - deploy_path: ./artifacts
-        - is_compress: "true"
 
   deploy_docs:
     before_run:
@@ -63,6 +53,15 @@ workflows:
         inputs:
         - update_fastlane: 'false'
         - lane: deploy_ghpages ghpages_url:$GIT_REPOSITORY_URL github_token:$PUBLISHER_GITHUB_API_TOKEN
+
+  _deploy_artifacts:
+    steps:
+    - deploy-to-bitrise-io@2:
+        is_skippable: true
+        inputs:
+        - is_enable_public_page: "false"
+        - deploy_path: ./artifacts
+        - is_compress: "true"
 
   integration_tests:
     before_run:

--- a/shared-bitrise.yml
+++ b/shared-bitrise.yml
@@ -16,6 +16,12 @@ workflows:
         - update_fastlane: 'false'
         - lane: ci
         title: Build & Test
+    - deploy-to-bitrise-io@2:
+        is_skippable: true
+        inputs:
+        - is_enable_public_page: "false"
+        - deploy_path: ./artifacts
+        - is_compress: "true"
 
   deploy:
     before_run:
@@ -32,6 +38,12 @@ workflows:
 
             bundle exec pod spec lint --allow-warnings
             bundle exec pod trunk push --allow-warnings --verbose
+    - deploy-to-bitrise-io@2:
+        is_skippable: true
+        inputs:
+        - is_enable_public_page: "false"
+        - deploy_path: ./artifacts
+        - is_compress: "true"
 
   deploy_docs:
     before_run:


### PR DESCRIPTION
the step will compress and export `./artifacts` dir if it exists. If it doesn't exist - it won't fail the build