### PR TITLE
chore: update dependency-check-cli to 7.1.0

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -181,6 +181,7 @@ platform :ios do
       project_name: ENV['REM_FL_TESTS_SLATHER_BASENAME'] || 'Project',
       output_types: 'html, json',
       skip_spm_analysis: true,
+      cli_version: '7.1.0',
       output_directory: 'artifacts'
     )
   end


### PR DESCRIPTION
Was trying to solve this issue:
>Unable to download meta file: https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2003.meta
[20:56:21]: ▸ org.owasp.dependencycheck.data.update.exception.UpdateException: Unable to download meta file: https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2003.meta

The [`fastlane-plugin-dependency_check_ios_analyzer`](https://github.com/alteral/fastlane-plugin-dependency_check_ios_analyzer) plugin is hardcoded to pull [`dependency-check-cli`](https://github.com/jeremylong/DependencyCheck) 6.2.2 which is super outdated.