### PR TITLE
improve: version-select overflow as flex columns instead of off the page (SDKCF-5535)

### DIFF
--- a/jazzy_themes/apple_versions/assets/css/version-select.css.scss
+++ b/jazzy_themes/apple_versions/assets/css/version-select.css.scss
@@ -47,9 +47,6 @@ button {
 .version-dropdown-content {
   display: none;
   position: absolute;
-  background-color: $content_bg_color;
-  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-  z-index: 1;
 }
 
 .version-dropdown-content a {
@@ -58,9 +55,17 @@ button {
   text-decoration: none;
   display: block;
   white-space: nowrap;
+  background-color: $content_bg_color;
+  box-shadow: 0px 4px 2px 0px rgba(0,0,0,0.2);
+  z-index: 1;
   width: -webkit-fill-available;
 }
 
 .version-dropdown-content a:hover {background-color: $content_bg_color_hover}
 
-.show {display:block;}
+.show {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  max-height: 350px;
+}

--- a/jazzy_themes/apple_versions/assets/css/version-select.css.scss
+++ b/jazzy_themes/apple_versions/assets/css/version-select.css.scss
@@ -51,7 +51,7 @@ button {
 
 .version-dropdown-content a {
   color: black;
-  padding: 4px 6px;
+  padding: 2px 6px;
   text-decoration: none;
   display: block;
   white-space: nowrap;


### PR DESCRIPTION
Adding too many versions will cause the 1-column version selector to run off the page without any ability to click on the newer/bottom versions.

Overflowing the version divs into flex columns should allow us to display up to ~100 versions on most displays without looking too weird. Tested on Safari and Edge/Chromium.