### PR TITLE
ci: dependency_check_ios_analyzer SPM check (SDKCF-5034)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -183,10 +183,20 @@ platform :ios do
 
   desc "Run OWASP Dependency Check"
   lane :check_dependencies do |options|
+    # Check Cocoapods
     dependency_check_ios_analyzer(
       project_name: ENV['REM_FL_TESTS_SLATHER_BASENAME'] || 'Project',
       output_types: 'html, json',
       skip_spm_analysis: true,
+      cli_version: '7.1.0',
+      output_directory: 'artifacts'
+    )
+    # Check SPM
+    dependency_check_ios_analyzer(
+      project_path: ENV['REM_FL_SPM_DIR_CONTAINING_XCODEPROJ'] || '.',
+      project_name: ENV['REM_FL_TESTS_SLATHER_BASENAME'] || 'Project',
+      output_types: 'html, json',
+      skip_pods_analysis: true,
       cli_version: '7.1.0',
       output_directory: 'artifacts'
     )


### PR DESCRIPTION
## What's new?
Add a SPM dependencies scan via `dependency_check_ios_analyzer`.

Had to invoke the `dependency_check_ios_analyzer` action a second time because it [assumes the `project_path` (xcodeproj containing dir) is the same for both the pods and SPM projects](https://github.com/alteral/fastlane-plugin-dependency_check_ios_analyzer/blob/a78106c71f65fc9b1cebf4ad0f26be21cfd4bb2d/lib/fastlane/plugin/dependency_check_ios_analyzer/helper/analyzer_helper.rb#L87) (which it isn't in our case).


## Usage

In IAM (or CI), set the `REM_FL_SPM_DIR_CONTAINING_XCODEPROJ` to [`SampleSPM`](https://github.com/rakutentech/ios-inappmessaging/tree/master/SampleSPM). If omitted, the action will just use the same path for the xcodeproj as the Pods check.

```bash
REM_FL_SPM_DIR_CONTAINING_XCODEPROJ=SampleSPM bundle exec fastlane ios check_dependencies
```

SPM results will appear in `./artifacts/SwiftPackages/report/`