### PR TITLE
fix: use xcpretty in scan to fix test report generation warnings (SDKCF-5616)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,7 @@ platform :ios do
       scheme: ENV['REM_FL_TESTS_SCHEME'] || 'Tests',
       device: ENV['REM_FL_TESTS_DEVICE'] || 'iPhone 11',
       code_coverage: true,
+      xcodebuild_formatter: 'xcpretty',
       slack_only_on_failure: true,
       skip_slack: ENV['PREVIOUS_BUILD_STATUS'] == 'error', # var defined in Bitrise step
       output_types: 'html,junit',


### PR DESCRIPTION
Using xcpretty is necessary to avoid following issues:
```
[22:59:24]: Skipping HTML... only available with `xcodebuild_formatter: 'xcpretty'` right now
[22:59:24]: Skipping JSON Compilation Database... only available with `xcodebuild_formatter: 'xcpretty'` right now
[22:59:24]: Your 'xcodebuild_formatter' doesn't support these 'output_types'. Change your 'output_types' to prevent these warnings from showing...
```
By default, Fastalne uses `xcbeautify` (if installed).
