### PR TITLE
fix: fix `integration_tests` workflow (Xcode 14 support)

### DIFF
--- a/shared-bitrise.yml
+++ b/shared-bitrise.yml
@@ -100,11 +100,10 @@ workflows:
     before_run:
     - _setup
     steps:
-    - xcode-test@2:
+    - xcode-test@4:
         inputs:
-        - simulator_device: iPhone 8
         - scheme: IntegrationTests
-        - should_build_before_test: 'no'
+        - destination: platform=iOS Simulator,name=iPhone 14,OS=latest
     - cache-push@2:
         inputs:
         - cache_paths: |-


### PR DESCRIPTION
`iPhone 8` is not available by default in Xcode 14.

Updated xcode-test step from v2 to v4