### PR TITLE
improve: use Pod version of Swiftlint if available (Fastfile)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -174,10 +174,12 @@ platform :ios do
 
     if File.exist?('../.swiftlint.yml')
       begin
+        swiftlint_pod_path = 'Pods/SwiftLint/swiftlint'
         swiftlint(
           mode: :lint,
           strict: true,
           config_file: '.swiftlint.yml',
+          executable: File.exist?("../#{swiftlint_pod_path}") ? swiftlint_pod_path : nil,
           ignore_exit_status: false)
       rescue
         UI.error '`swiftlint` found a problem. Please check the logs above'


### PR DESCRIPTION
With this improvement it will be possible to set a specific version of Swiftlint that is used by Xcode and CI build process regardless of build stack settings.
(e.g. Swiftlint 0.49+ can't be used on macOS 11/Xcode 12.5, plus the new versions has different rule violation detection)