### PR TITLE
fix: Install cocoapods before generating documentation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -114,7 +114,8 @@ platform :ios do
       end
     end
 
-    puts "generate documenation for #{module_name} version #{release_tag}"
+    puts "generate documentation for #{module_name} version #{release_tag}"
+    cocoapods()
     documentation(
       module_name: module_name,
       module_version: release_tag


### PR DESCRIPTION
## Description
This error is returned when documentation is being generated during the release lane process:
`xcodebuild: error: 'Pods/Pods.xcodeproj' does not exist.`

This PR adds the generation of `Pods/Pods.xcodeproj` before starting the documentation generation.