### PR TITLE
improve: fetch release tag for SPM only support SDK from Bitrise env variable

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -93,7 +93,11 @@ platform :ios do
   desc 'Module Pre-Release checks'
   lane :release do |options|
 
-    release_tag = version_get_podspec(path: ENV['REM_FL_PODSPEC_FILE'])
+    if File.exist?('../Podfile')
+      release_tag = version_get_podspec(path: ENV['REM_FL_PODSPEC_FILE'])
+    else
+      release_tag = options[:module]
+    end
     module_name = options[:module]
     release_branch = options[:branch]
 


### PR DESCRIPTION
Description:
Release tag was fetched from the Pod Spec file which does not support the SPM package. so now one check has been added to fetch the release tag version from Bitrise env variable.