### PR TITLE
fix: replace unsupported svn command from github to use git clone

### DIFF
--- a/fastlane/actions/documentation.rb
+++ b/fastlane/actions/documentation.rb
@@ -15,8 +15,9 @@ module Fastlane
         Dir.chdir(workspace) do
           if docgen_script.empty?
             # running default script
-            UI.user_error!("svn not installed") unless system("command -v svn")
-            sh "svn export https://github.com/rakutentech/ios-buildconfig/trunk/jazzy_themes jazzy_themes --force"
+            sh "git clone https://github.com/rakutentech/ios-buildconfig"
+            sh "mv ios-buildconfig/jazzy_themes ."
+            sh "rm -rf ios-buildconfig"
             sh "bundle exec jazzy --output artifacts/docs/#{module_version} --theme jazzy_themes/apple_versions"
           else
             sh("#{docgen_script} #{module_name} #{module_version}")


### PR DESCRIPTION
SVN support has been removed from Github On January 8, 2024.
Source: https://github.blog/2023-01-20-sunsetting-subversion-support/

This PR was made to replace the svn usage to use git clone instead.